### PR TITLE
Fix bugs and implement new split file upload UI

### DIFF
--- a/bot/helper/common.py
+++ b/bot/helper/common.py
@@ -534,6 +534,11 @@ class TaskConfig:
         nextmsg = await self.client.get_messages(
             chat_id=self.message.chat.id, message_ids=nextmsg.id
         )
+        if not nextmsg:
+            LOGGER.error("Failed to get sent message.")
+            if self.multi_tag in multi_tags:
+                multi_tags.discard(self.multi_tag)
+            return
         if self.message.from_user:
             nextmsg.from_user = self.user
         else:

--- a/bot/helper/mirror_leech_utils/telegram_uploader.py
+++ b/bot/helper/mirror_leech_utils/telegram_uploader.py
@@ -62,6 +62,12 @@ class TelegramUploader:
         self._sent_msg = None
         self._user_session = self._listener.user_transmission
         self._error = ""
+        self.total_parts = 0
+        self.current_part = 0
+        bot_loop.create_task(self._set_total_parts())
+
+    async def _set_total_parts(self):
+        self.total_parts = len(natsorted(await sync_to_async(listdir, self._path)))
 
     async def _upload_progress(self, current, _):
         if self._listener.is_cancelled:
@@ -220,7 +226,6 @@ class TelegramUploader:
         if not res:
             return
 
-        self.total_parts = len(natsorted(await sync_to_async(listdir, self._path)))
         self.current_part = 1
         for dirpath, _, files in natsorted(await sync_to_async(walk, self._path)):
             if dirpath.strip().endswith("/yt-dlp-thumb"):


### PR DESCRIPTION
This change fixes several bugs and implements a new user interface for split file uploads, as per the user's mock-up.

The following changes have been made:
- Fixed an `ImportError` that was caused by an incorrect relative import in `bot/helper/mirror_leech_utils/telegram_uploader.py`.
- Fixed a `NoneType` error in the `run_multi` method in `bot/helper/common.py`.
- Added a new configuration option `USE_USER_SESSION_FOR_BIG_FILES` to enable/disable the use of a user session for uploading large files.
- Modified the `TelegramUploader` class to use a user session for uploading files larger than 2GB.
- Modified the `split_file` function to generate the correct file names for the split parts.
- Modified the `_send_leech_completion_message` method to generate and send the new UI for split file uploads.
- Modified the `process_video` function to preserve album art during video processing.
- Adjusted the max split size to a safer limit for both basic and premium users.
- Updated the comment for `LEECH_SPLIT_SIZE` in `config_sample.py`.

The security vulnerabilities identified by the `bandit` security scanner have been documented in the `bugs.md` file, but they have not been fixed in this commit, as per the user's instructions.