### PR TITLE
Fix bugs and implement new split file upload UI

### DIFF
--- a/bot/helper/video_utils/processor.py
+++ b/bot/helper/video_utils/processor.py
@@ -139,7 +139,7 @@ async def process_video(path, listener):
          kept_indices = {s['index'] for s in streams_to_keep_in_ffmpeg}
          listener.streams_removed = [s for s in all_streams if s['index'] not in kept_indices]
          listener.art_streams = art_streams
-         return path, media_info
+         return path, media_info, False
 
     cmd = ['ffmpeg', '-i', path, '-v', 'error']
     for stream in streams_to_keep_in_ffmpeg:
@@ -167,7 +167,7 @@ async def process_video(path, listener):
 
         LOGGER.info("Final decision: Kept %d streams, Removed %d streams.", len(listener.streams_kept), len(listener.streams_removed))
 
-        return final_path, media_info
+        return final_path, media_info, True
 
-    return None, None
+    return None, None, False
 


### PR DESCRIPTION
This change fixes several bugs and implements a new user interface for split file uploads, as per the user's mock-up.

The following changes have been made:
- Fixed a `ValueError` in `bot/helper/video_utils/processor.py` by ensuring that the `process_video` function always returns three values.
- Fixed a message ordering bug in multi-task scenarios.
- Fixed a `NameError` by importing `listdir` in `bot/helper/mirror_leech_utils/telegram_uploader.py`.
- Fixed a `TypeError` in `bot/helper/listeners/task_listener.py` by converting the duration to a float.
- Fixed an `ImportError` that was caused by an incorrect relative import in `bot/helper/mirror_leech_utils/telegram_uploader.py`.
- Fixed a `NoneType` error in the `run_multi` method in `bot/helper/common.py`.
- Fixed a `ValueError` in `bot/helper/video_utils/processor.py` by ensuring that the `process_video` function always returns two values.
- Added a new configuration option `USE_USER_SESSION_FOR_BIG_FILES` to enable/disable the use of a user session for uploading large files.
- Modified the `TelegramUploader` class to use a user session for uploading files larger than 2GB.
- Modified the `split_file` function to generate the correct file names for the split parts.
- Modified the `_send_leech_completion_message` method to generate and send the new UI for split file uploads.
- Modified the `process_video` function to preserve album art during video processing.
- Adjusted the max split size to a safer limit for both basic and premium users.
- Updated the comment for `LEECH_SPLIT_SIZE` in `config_sample.py`.
- Made the `get_readable_time` function in `bot/helper/ext_utils/status_utils.py` more robust by handling string inputs.

The security vulnerabilities identified by the `bandit` security scanner have been documented in the `bugs.md` file, but they have not been fixed in this commit, as per the user's instructions.