### PR TITLE
fix: Resolve NameError for time in TaskListener

### DIFF
--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -2,6 +2,7 @@ from aiofiles.os import path as aiopath, listdir, remove
 from asyncio import sleep, gather
 from os import path as ospath
 import os
+from time import time
 from html import escape
 from requests import utils as rutils
 


### PR DESCRIPTION
This commit fixes a `NameError: name 'time' is not defined` that occurred during the initialization of the `TaskListener` class.

The error was caused by the `from time import time` statement being located in a scope that was not accessible at the module level when the class was defined.

This commit resolves the issue by moving `from time import time` to the top of `bot/helper/listeners/task_listener.py` with the other module-level imports. This ensures `time` is in scope when `TaskListener.__init__` is called, preventing the `NameError` and allowing the bot to start correctly.