### PR TITLE
Refactor TelegramUploader and add error handling for leech tasks.

### DIFF
--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -213,12 +213,10 @@ class TaskListener(TaskConfig):
             async with task_dict_lock:
                 task_dict[self.mid] = TelegramStatus(self, tg, gid, "up")
 
-            self.total_parts = tg.total_parts
             async for sent_message in tg.upload():
                 if self.is_cancelled:
                     break
                 if sent_message:
-                    self.current_part = tg.current_part
                     await self._send_leech_completion_message(sent_message)
 
             if self.is_cancelled:
@@ -374,7 +372,13 @@ class TaskListener(TaskConfig):
         if sent_message.link:
             buttons.url_button("Download Link", sent_message.link)
         reply_markup = buttons.build_menu(2) if buttons._button else None
-        await send_message(sent_message, msg, reply_markup)
+        try:
+            await send_message(sent_message, msg, reply_markup)
+        except RPCError as e:
+            LOGGER.error(f"Failed to send completion message: {e}")
+            if "BUTTON_URL_INVALID" in str(e) and sent_message.link:
+                LOGGER.warning("Retrying without the button...")
+                await send_message(sent_message, msg)
 
     async def on_upload_complete(
         self, link, files, folders, mime_type, rclone_path="", dir_id="", tg_sent_messages=None

--- a/bot/helper/mirror_leech_utils/telegram_uploader.py
+++ b/bot/helper/mirror_leech_utils/telegram_uploader.py
@@ -63,12 +63,8 @@ class TelegramUploader:
         self._sent_msg = None
         self._user_session = self._listener.user_transmission
         self._error = ""
-        self.total_parts = 0
-        self.current_part = 0
-        bot_loop.create_task(self._set_total_parts())
-
-    async def _set_total_parts(self):
-        self.total_parts = len(natsorted(await sync_to_async(listdir, self._path)))
+        self._listener.total_parts = 0
+        self._listener.current_part = 0
 
     async def _upload_progress(self, current, _):
         if self._listener.is_cancelled:
@@ -227,7 +223,10 @@ class TelegramUploader:
         if not res:
             return
 
-        self.current_part = 1
+        self._listener.total_parts = len(
+            natsorted(await sync_to_async(listdir, self._path))
+        )
+        self._listener.current_part = 1
         for dirpath, _, files in natsorted(await sync_to_async(walk, self._path)):
             if dirpath.strip().endswith("/yt-dlp-thumb"):
                 continue
@@ -300,7 +299,7 @@ class TelegramUploader:
                     self._up_path
                 ):
                     await remove(self._up_path)
-                self.current_part += 1
+                self._listener.current_part += 1
         for key, value in list(self._media_dict.items()):
             for subkey, msgs in list(value.items()):
                 if len(msgs) > 1:


### PR DESCRIPTION
This change addresses potential race conditions and error handling issues related to multi-file leech uploads.

- Refactored the `TelegramUploader` to synchronously calculate the total number of parts and to be the single source of truth for updating the `current_part` on the `TaskListener`. This prevents a race condition where the listener might access the `total_parts` count before it's calculated.

- Added a `try...except` block in the `TaskListener` when sending the completion message. This catches the `BUTTON_URL_INVALID` RPCError, logs it, and retries sending the message without the button, preventing a crash and ensuring the user is notified of task completion.