### PR TITLE
This commit fixes an IndentationError in `bot/helper/listeners/task_l…

### DIFF
--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -228,8 +228,8 @@ class TaskListener(TaskConfig):
             if self.is_cancelled:
                 return
 
-    if self.status_message:
-        await delete_message(self.status_message)
+            if self.status_message:
+                await delete_message(self.status_message)
 
             # Final cleanup for leech tasks
             await clean_download(self.dir)
@@ -245,7 +245,6 @@ class TaskListener(TaskConfig):
                 if self.mid in non_queued_up:
                     non_queued_up.remove(self.mid)
             await start_from_queued()
-
         elif is_gdrive_id(self.up_dest):
             LOGGER.info(f"Gdrive Upload Name: {self.name}")
             drive = GoogleDriveUpload(self, up_path)


### PR DESCRIPTION
…istener.py`.

The error was caused by a block of code related to post-leech cleanup being incorrectly indented, which broke the `if/elif/else` structure of the upload handling logic.

This change corrects the indentation, ensuring the cleanup code is properly nested within the `if self.is_leech:` block. This resolves the syntax error and allows the bot to run correctly.