### PR TITLE
This commit fixes a `NameError` that occurred in `bot/helper/video_ut…

### DIFF
--- a/bot/helper/video_utils/processor.py
+++ b/bot/helper/video_utils/processor.py
@@ -7,7 +7,7 @@ import asyncio
 import json
 from time import time
 import os.path as ospath
-from aiofiles.os import rename as aiorename
+from aiofiles.os import rename as aiorename, path as aiopath
 
 async def get_media_info(path):
     """Get media information using ffprobe."""


### PR DESCRIPTION
…ils/processor.py`.

The error was caused by a call to `aiopath.exists()` without the `aiopath` module being imported. This change adds the missing import to the file, resolving the crash during video processing.