### PR TITLE
This commit fixes a "File size is zero" error that occurred after a f…

### DIFF
--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -198,9 +198,13 @@ class TaskListener(TaskConfig):
             self.name = up_path.replace(f"{self.dir}/", "").split("/", 1)[0]
 
         if self.is_leech and not self.compress:
+            is_file = self.is_file
             await self.proceed_split(up_path, gid)
-            if self.is_cancelled: return
+            if self.is_cancelled:
+                return
             self.clear()
+            if is_file:
+                up_path = ospath.dirname(up_path)
 
         self.size = await get_path_size(up_path)
         if self.size == 0:


### PR DESCRIPTION
…ile was split for a leech task.

The error was caused by the code attempting to get the size of the original file path after the file had been deleted by the splitting process.

The fix involves updating the file path to point to the parent directory (which contains the new split parts) if the original path was a single file. This ensures that `get_path_size` is called on a valid path, correctly calculating the total size of all the split parts.