### PR TITLE
This commit fixes an `AttributeError: module 'posixpath' has no attri…

### DIFF
--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -1,6 +1,6 @@
 from aiofiles.os import path as aiopath, listdir, remove
 from asyncio import sleep, gather
-from os import path as ospath
+from os import path as ospath, walk
 from html import escape
 from requests import utils as rutils
 
@@ -161,7 +161,7 @@ class TaskListener(TaskConfig):
             self.name = up_path.replace(f"{self.dir}/", "").split("/", 1)[0]
 
         if await aiopath.isdir(up_path):
-            for root, _, files in await sync_to_async(ospath.walk, up_path):
+            for root, _, files in await sync_to_async(walk, up_path):
                 for file in files:
                     file_path = ospath.join(root, file)
                     if not await is_video(file_path):


### PR DESCRIPTION
…bute 'walk'` that occurred in `bot/helper/listeners/task_listener.py`.

The error was caused by an incorrect call to `ospath.walk` (which is an alias for `os.path.walk`). The `walk` function resides in the top-level `os` module.

This change imports `walk` directly from `os` and updates the function call to use it, resolving the crash when processing downloaded directories.