### PR TITLE
fix: Resolve global import errors in helper modules

### DIFF
--- a/bot/helper/__init__.py
+++ b/bot/helper/__init__.py
@@ -1,1 +1,15 @@
-from .. import LOGGER
+from .. import (
+    LOGGER,
+    DOWNLOAD_DIR,
+    task_dict,
+    task_dict_lock,
+    queue_dict_lock,
+    non_queued_dl,
+    non_queued_up,
+    intervals,
+    user_data,
+    auth_chats,
+    sudo_users,
+    rss_dict,
+    same_directory_lock,
+)


### PR DESCRIPTION
This commit fixes the `ImportError` for `task_dict` and other global variables that were not being correctly exposed to the `bot.helper` sub-package.

The `bot/helper/__init__.py` file has been updated to import a comprehensive list of necessary global variables (like `task_dict`, `task_dict_lock`, `DOWNLOAD_DIR`, etc.) from the main `bot` package. This makes them available for all helper modules and prevents a class of import-related crashes.

This change directly addresses the traceback provided by the user and aims to improve the overall stability of the import system.