### PR TITLE
Fix ModuleNotFoundError and subsequent startup errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ cookies.txt
 downloads/*
 *.session
 *.env
+__pycache__/
+*.pyc

--- a/bot/core/mltb_client.py
+++ b/bot/core/mltb_client.py
@@ -1,5 +1,6 @@
 from pyrogram import Client, enums
 from asyncio import Lock
+from os import getcwd
 
 from .. import LOGGER
 from .config_manager import Config
@@ -24,7 +25,7 @@ class TgClient:
             Config.TELEGRAM_HASH,
             proxy=Config.TG_PROXY,
             bot_token=Config.BOT_TOKEN,
-            workdir="/usr/src/app",
+            workdir=getcwd(),
             parse_mode=enums.ParseMode.HTML,
             max_concurrent_transmissions=10,
         )

--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -43,7 +43,7 @@ from ..mirror_leech_utils.status_utils.rclone_status import RcloneStatus
 from ..mirror_leech_utils.status_utils.telegram_status import TelegramStatus
 from ..mirror_leech_utils.telegram_uploader import TelegramUploader
 from ..telegram_helper.button_build import ButtonMaker
-from ..video_utils.processor import process_video
+from ..video_utils.executor import VidEcxecutor
 from ..telegram_helper.message_utils import (
     send_message,
     delete_status,
@@ -125,17 +125,14 @@ class TaskListener(TaskConfig):
         if self.status_message:
             await edit_message(self.status_message, f"🎬 **Processing:** `{self.name}` 🔄")
 
-        interval = SetInterval(3, self._update_ffmpeg_progress)
-        result = await process_video(file_path, self)
-        interval.cancel()
+        self.vidMode = ("rmstream", self.name, {})
+        executor = VidEcxecutor(self, file_path, self.gid)
+        up_path = await executor.execute()
 
-        if self.is_cancelled or result is None or (isinstance(result, tuple) and result[0] is None):
+        if self.is_cancelled or not up_path:
             LOGGER.error(f"Skipping {self.name} due to processing failure.")
             await self._upload_file(file_path)
             return
-
-        up_path = result[0]
-        self.media_info = result[1]
         self.size = await get_path_size(up_path)
 
         self.file_metadata[self.name] = {

--- a/bot/helper/video_utils/executor.py
+++ b/bot/helper/video_utils/executor.py
@@ -321,9 +321,12 @@ class VidEcxecutor(FFProgress):
             streams = self._metadata[0]
         else:
             main_video = file_list[0]
-            base_dir, (streams, _), self.size = await gather(self._name_base_dir(main_video, 'Remove', multi),
-                                                             get_metavideo(main_video), get_path_size(main_video))
-        self._start_handler(streams)
+            base_dir, (streams, self.listener.media_info), self.size = await gather(self._name_base_dir(main_video, 'Remove', multi),
+                                                                                    get_metavideo(main_video), get_path_size(main_video))
+        if hasattr(self.listener, 'auto_process') and self.listener.auto_process:
+            await ExtraSelect(self).auto_select(streams)
+        else:
+            self._start_handler(streams)
         await gather(self._send_status(), self.event.wait())
         await self._queue()
         if self.is_cancel:


### PR DESCRIPTION
- Fix `ModuleNotFoundError: No module named 'bot.helper.video_utils.processor'` by updating `task_listener.py` to use `VidEcxecutor` instead of the deleted `process_video` function.
- Modify `executor.py` to handle `auto_process` and to store `media_info` on the listener, ensuring that video processing and completion messages work correctly.
- Fix `sqlite3.OperationalError: unable to open database file` by changing the hardcoded `workdir` in `mltb_client.py` to use the current working directory.
- Add `__pycache__/` and `*.pyc` to `.gitignore` to prevent compiled Python files from being tracked.