### PR TITLE
Fix two runtime errors from log analysis

### DIFF
--- a/bot/helper/listeners/qbit_listener.py
+++ b/bot/helper/listeners/qbit_listener.py
@@ -84,19 +84,19 @@ async def _on_download_complete(tor):
                 else:
                     removed = True
             if removed:
-                await _remove_torrent(ext_hash, tag)
+                await _remove_torrent(tor.hash, ext_hash)
                 return
             async with qb_listener_lock:
-                if tag in qb_torrents:
-                    qb_torrents[tag]["seeding"] = True
+                if ext_hash in qb_torrents:
+                    qb_torrents[ext_hash]["seeding"] = True
                 else:
                     return
             await update_status_message(task.listener.message.chat.id)
             LOGGER.info(f"Seeding started: {tor.name} - Hash: {ext_hash}")
         else:
-            await _remove_torrent(ext_hash, tag)
+            await _remove_torrent(tor.hash, ext_hash)
     else:
-        await _remove_torrent(ext_hash, tag)
+        await _remove_torrent(tor.hash, ext_hash)
 
 
 @new_task

--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -113,13 +113,15 @@ class TaskListener(TaskConfig):
         if self.is_cancelled:
             return
 
+        gid = getattr(self, "gid", self.mid)
+
         dl_path = f"{self.dir}/{self.name}"
         up_path = dl_path
 
         # Step 1: Extract if it's a ZIP/RAR
         if self.extract and is_archive(up_path):
             LOGGER.info(f"Extracting archive: {up_path}")
-            up_path = await self.proceed_extract(up_path, self.gid)
+            up_path = await self.proceed_extract(up_path, gid)
             if not up_path or self.is_cancelled:
                 return
             # After extract, up_path is now a directory with extracted files


### PR DESCRIPTION
This commit addresses two distinct runtime errors identified from user-provided logs.

1.  **Fix `AttributeError` for Telegram Downloads:** In `bot/helper/listeners/task_listener.py`, an `AttributeError` would occur when processing a direct Telegram download because no download `gid` was assigned. This caused a crash during post-processing steps like extraction. The fix introduces a fallback, using the message ID (`mid`) as the unique identifier if `gid` is not present, ensuring stability for all download types.

2.  **Fix `NameError` in qBittorrent Listener:** In `bot/helper/listeners/qbit_listener.py`, a `NameError` would occur after a qBittorrent download completed because the cleanup function was called with an undefined `tag` variable. This has been corrected to use the proper variables (`tor.hash` and `ext_hash`), allowing the torrent to be correctly removed from the client after the task is finished.