### PR TITLE
Fix: Clear asyncio event in YtSelection

### DIFF
--- a/bot/modules/ytdlp.py
+++ b/bot/modules/ytdlp.py
@@ -75,6 +75,7 @@ class YtSelection:
         self.qual = None
 
     async def _event_handler(self):
+        self.event.clear()
         pfunc = partial(select_format, obj=self)
         handler = self.listener.client.add_handler(
             CallbackQueryHandler(


### PR DESCRIPTION
The /leech command would get stuck at "analysing streams" on subsequent uses because the asyncio.Event in the YtSelection class was not being cleared. This change adds a call to self.event.clear() at the beginning of the _event_handler method to ensure that the event is reset for each new selection process.