### PR TITLE
Fix critical startup and video processing bugs

### DIFF
--- a/bot/core/config_manager.py
+++ b/bot/core/config_manager.py
@@ -150,6 +150,16 @@ class Config:
         if isinstance(converted_value, str):
             converted_value = converted_value.strip()
 
+        if attr == "PREFERRED_LANGUAGES":
+            if isinstance(converted_value, str) and converted_value.startswith('[') and converted_value.endswith(']'):
+                try:
+                    lang_list = literal_eval(converted_value)
+                    if isinstance(lang_list, list):
+                        converted_value = ",".join(str(l).strip() for l in lang_list)
+                except (ValueError, SyntaxError):
+                    pass
+            return converted_value
+
         if attr == "DEFAULT_UPLOAD" and converted_value != "gd":
             return "rc"
 

--- a/bot/helper/ext_utils/bot_utils.py
+++ b/bot/helper/ext_utils/bot_utils.py
@@ -251,3 +251,5 @@ def loop_thread(func):
         return future.result() if wait else future
 
     return wrapper
+
+new_thread = sync_to_async

--- a/bot/helper/ext_utils/media_utils.py
+++ b/bot/helper/ext_utils/media_utils.py
@@ -7,6 +7,7 @@ from asyncio import (
     sleep,
 )
 from asyncio.subprocess import PIPE
+from json import JSONDecodeError, loads as json_loads
 from os import path as ospath
 from re import search as re_search, escape
 from time import time
@@ -50,7 +51,10 @@ async def get_media_info(path):
         LOGGER.error(f"Get Media Info: {e}. Mostly File not found! - File: {path}")
         return 0, None, None
     if result[0] and result[2] == 0:
-        fields = eval(result[0]).get("format")
+        try:
+            fields = json_loads(result[0]).get("format")
+        except JSONDecodeError:
+            fields = None
         if fields is None:
             LOGGER.error(f"get_media_info: {result}")
             return 0, None, None
@@ -98,7 +102,10 @@ async def get_document_type(path):
             is_video = True
         return is_video, is_audio, is_image
     if result[0] and result[2] == 0:
-        fields = eval(result[0]).get("streams")
+        try:
+            fields = json_loads(result[0]).get("streams")
+        except JSONDecodeError:
+            fields = None
         if fields is None:
             LOGGER.error(f"get_document_type: {result}")
             return is_video, is_audio, is_image

--- a/bot/helper/listeners/task_listener.py
+++ b/bot/helper/listeners/task_listener.py
@@ -1,7 +1,9 @@
 from aiofiles.os import path as aiopath, listdir, remove
 from asyncio import sleep, gather
+from base64 import b64encode
 from os import path as ospath
 from html import escape
+from re import match as re_match
 from requests import utils as rutils
 
 from ... import (
@@ -20,8 +22,9 @@ from ... import (
 from ...core.config_manager import Config
 from ...core.torrent_manager import TorrentManager
 from ..common import TaskConfig
-from ..ext_utils.bot_utils import sync_to_async
+from ..ext_utils.bot_utils import sync_to_async, get_content_type
 from ..ext_utils.db_handler import database
+from ..ext_utils.exceptions import DirectDownloadLinkException
 from ..ext_utils.files_utils import (
     get_path_size,
     clean_download,
@@ -32,17 +35,31 @@ from ..ext_utils.files_utils import (
     move_and_merge,
     is_video,
     is_archive,
+    get_base_name,
+    extract_archive,
 )
-from ..ext_utils.links_utils import is_gdrive_id
+from ..ext_utils.links_utils import is_gdrive_id, is_magnet, is_rclone_path, is_gdrive_link
 from ..ext_utils.status_utils import get_readable_file_size
 from ..ext_utils.task_manager import start_from_queued, check_running_tasks
+from ..mirror_leech_utils.download_utils.aria2_download import add_aria2_download
+from ..mirror_leech_utils.download_utils.direct_downloader import add_direct_download
+from ..mirror_leech_utils.download_utils.direct_link_generator import (
+    direct_link_generator,
+)
+from ..mirror_leech_utils.download_utils.gd_download import add_gd_download
+from ..mirror_leech_utils.download_utils.jd_download import add_jd_download
+from ..mirror_leech_utils.download_utils.nzb_downloader import add_nzb
+from ..mirror_leech_utils.download_utils.qbit_download import add_qb_torrent
+from ..mirror_leech_utils.download_utils.rclone_download import add_rclone_download
+from ..mirror_leech_utils.download_utils.telegram_download import (
+    TelegramDownloadHelper,
+)
 from ..mirror_leech_utils.gdrive_utils.upload import GoogleDriveUpload
 from ..mirror_leech_utils.rclone_utils.transfer import RcloneTransferHelper
 from ..mirror_leech_utils.status_utils.gdrive_status import GoogleDriveStatus
 from ..mirror_leech_utils.status_utils.queue_status import QueueStatus
 from ..mirror_leech_utils.status_utils.rclone_status import RcloneStatus
 from ..mirror_leech_utils.status_utils.telegram_status import TelegramStatus
-from ..mirror_leech_utils.telegram_uploader import TelegramUploader
 from ..telegram_helper.button_build import ButtonMaker
 from ..video_utils.processor import process_video
 from ..telegram_helper.message_utils import (
@@ -76,6 +93,9 @@ class TaskListener(TaskConfig):
         self.file_ = None
         self.session = ""
         self.path = ""
+        self.total_parts = 1
+        self.current_part = 1
+        self.original_name = ""
 
     async def on_task_created(self):
         self.status_message = await send_message(self.message, "🎬 Analyzing Streams... ⏳")
@@ -179,6 +199,13 @@ class TaskListener(TaskConfig):
                 self.message.chat.id, self.message.link, self.tag
             )
 
+    async def proceed_extract(self, up_path, gid):
+        try:
+            return await extract_archive(up_path, f"{self.dir}/{gid}")
+        except Exception as e:
+            await self.on_upload_error(str(e))
+            return None
+
     async def on_download_complete(self):
         if self.is_cancelled:
             return
@@ -226,6 +253,7 @@ class TaskListener(TaskConfig):
             await clean_download(self.up_dir)
 
     async def _process_single_video(self, up_path):
+        from ..mirror_leech_utils.telegram_uploader import TelegramUploader
         if self.is_leech and not self.compress:
             result = await process_video(up_path, self)
             if not result or self.is_cancelled:

--- a/bot/helper/video_utils/processor.py
+++ b/bot/helper/video_utils/processor.py
@@ -10,20 +10,26 @@ import os.path as ospath
 from aiofiles.os import rename as aiorename, path as aiopath
 
 async def get_media_info(path):
-    """Get media information using ffprobe."""
+    """Get media information using ffprobe with a timeout."""
     try:
         process = await asyncio.create_subprocess_exec(
             'ffprobe', '-hide_banner', '-loglevel', 'error', '-print_format', 'json',
             '-show_format', '-show_streams', path,
             stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE
         )
-        stdout, stderr = await process.communicate()
+        try:
+            stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=60)
+        except asyncio.TimeoutError:
+            LOGGER.error(f"ffprobe timed out while processing {path}")
+            process.kill()
+            return None
+
         if process.returncode != 0:
-            LOGGER.error(f"ffprobe error: {stderr.decode().strip()}")
+            LOGGER.error(f"ffprobe error for {path}: {stderr.decode().strip()}")
             return None
         return json.loads(stdout)
     except Exception as e:
-        LOGGER.error(f"Exception while getting media info: {e}")
+        LOGGER.error(f"Exception in get_media_info for {path}: {e}")
         return None
 
 async def run_ffmpeg(command, path, listener):


### PR DESCRIPTION
This commit addresses a series of critical bugs that prevented the bot from starting and caused it to hang during video processing.

The following issues have been resolved:

- **Circular Imports:** Fixed a circular import dependency between `task_listener.py` and `mirror_leech.py` by moving the `TelegramUploader` import to a local scope.
- **Missing Imports and Methods:** Added all missing imports in `task_listener.py` and implemented the missing `proceed_extract` method.
- **Undefined Variables:** Initialized `self.total_parts`, `self.current_part`, and `self.original_name` in the `TaskListener` class to prevent `AttributeError` exceptions.
- **Blocking Subprocess Calls:** Added a 60-second timeout to the `ffprobe` call in `processor.py` to prevent indefinite hangs.
- **Event Loop Blocking:** Implemented the missing `new_thread` decorator to ensure long-running event handlers in `selector.py` and `extra_selector.py` do not block the main event loop.
- **Insecure `eval()` Usage:** Replaced `eval()` with the safer `json.loads()` in `media_utils.py` to parse `ffprobe` output.
- **Configuration Validation:** Added validation for the `PREFERRED_LANGUAGES` setting in `config_manager.py` to handle various input formats gracefully.