### PR TITLE
Fix: Resolve critical startup and processing bugs

### DIFF
--- a/bot/helper/ext_utils/files_utils.py
+++ b/bot/helper/ext_utils/files_utils.py
@@ -269,15 +269,15 @@ async def join_files(opath):
 async def split_file(path, size, file_, listener):
     if listener.is_cancelled:
         return False
+    parts = -(-size // listener.split_size)
     base_name, extension = ospath.splitext(file_)
     split_size = listener.split_size
-    LOGGER.info(f"Splitting {file_} into parts of size {split_size}")
+    LOGGER.info(f"Splitting {file_} into {parts} parts.")
     cmd = [
         "split",
-        "--bytes",
-        str(split_size),
+        f"--bytes={split_size}",
         "--numeric-suffixes=1",
-        "--suffix-length=3",
+        f"--additional-suffix={extension}",
         path,
         f"{ospath.join(ospath.dirname(path), base_name)}.part",
     ]
@@ -287,6 +287,7 @@ async def split_file(path, size, file_, listener):
         LOGGER.error(f"Error while splitting file: {stderr.decode().strip()}")
         return False
     return True
+
 
 async def is_video(path):
     if not await aiopath.isfile(path):

--- a/bot/helper/mirror_leech_utils/telegram_uploader.py
+++ b/bot/helper/mirror_leech_utils/telegram_uploader.py
@@ -3,7 +3,7 @@ from aioshutil import rmtree
 from asyncio import sleep
 from logging import getLogger
 from natsort import natsorted
-from os import walk, path as ospath, listdir
+from os import walk, path as ospath
 from time import time
 from re import match as re_match, sub as re_sub
 from pyrogram.errors import FloodWait, RPCError, FloodPremiumWait, BadRequest
@@ -11,6 +11,7 @@ from aiofiles.os import (
     remove,
     path as aiopath,
     rename,
+    listdir,
 )
 from pyrogram.types import (
     InputMediaVideo,
@@ -249,7 +250,7 @@ class TelegramUploader:
             f_size = await aiopath.getsize(f_path)
             if f_size > 2097152000 and not f_path.endswith('.zip'):
                 LOGGER.info(f"Splitting file: {f_path}")
-                if not await split_file(f_path, f_size, self._listener):
+                if not await split_file(f_path, f_size, ospath.basename(f_path), self._listener):
                     return
                 dir_path = ospath.dirname(f_path)
                 base_name = ospath.basename(f_path)


### PR DESCRIPTION
This commit addresses a series of critical bugs that prevented the bot from starting up and caused it to hang or fail during video processing and file extraction.

The following key issues have been resolved:

- **Circular Import Resolution:** Fixed the primary circular dependency between `direct_downloader.py` and `mirror_leech.py` by using a `TYPE_CHECKING` block and a string forward reference.
- **Missing Imports and Methods:** Added all missing imports to `task_listener.py` to resolve `ImportError` exceptions at runtime.
- **Undefined Variables:** Initialized `total_parts`, `current_part`, and `original_name` in the `TaskListener` class.
- **Blocking Calls and Timeouts:** Added a 60-second timeout to all `ffprobe` calls in `media_utils.py` to prevent indefinite hangs and replaced insecure `eval()` calls with `json.loads()`.
- **Archive Extraction:** Implemented a robust `extract_archive` function in `files_utils.py` using the `7z` command-line utility.
- **Large File Splitting:** Implemented a `split_file` function and refactored `telegram_uploader.py` to correctly split files larger than 2GB and upload the parts sequentially.
- **Syntax Errors:** Corrected multiple `SyntaxError` exceptions in `mirror_leech.py` and `media_utils.py`.
- **Missing System Dependencies:** Added `ffmpeg` and `mediainfo` to the `Dockerfile` to ensure they are available in the runtime environment.